### PR TITLE
Remove from_json and to_json in Gigamonkey::Bitcoin. MatterPoolAPI is now MatterPool::API

### DIFF
--- a/include/MatterpoolAPI.h
+++ b/include/MatterpoolAPI.h
@@ -13,11 +13,17 @@
 #ifndef COSMOSWALLET_MATTERPOOLAPI_H
 #define COSMOSWALLET_MATTERPOOLAPI_H
 
-namespace Cosmos {
+namespace Cosmos::MatterPool {
+    
+    struct Header : Gigamonkey::Bitcoin::header {};
+    
+    void from_json(const json& j, Header& header);
+    void to_json(json& j, const Header& header);
 
-    class MatterpoolApi {
+    class Api {
     public:
-        MatterpoolApi() : rateLimit(100,60) {}
+        
+        Api() : rateLimit(100,60) {}
         data::list<Gigamonkey::Bitcoin::ledger::block_header> headers(data::uint64 since_height) ;
         void waitForRateLimit() ;
 
@@ -28,7 +34,9 @@ namespace Cosmos {
         json header(const Gigamonkey::digest<32> &digest);
         json header(data::uint64 height);
         data::uint64 transaction_height(Gigamonkey::digest256 &txid);
-        data::bytes raw_header(const Gigamonkey::digest<32> &digest) ;
+        data::bytes raw_header(const Gigamonkey::digest<32> &digest);
+        
+        static Gigamonkey::Bitcoin::header header_from_json();
 
         //data::list<Gigamonkey::Bitcoin::txid> transactions(const Gigamonkey::digest<32> &digest) const;
 

--- a/include/matterpool_timechain.h
+++ b/include/matterpool_timechain.h
@@ -36,7 +36,7 @@ namespace Cosmos {
     private:
         mutable data::tools::rate_limiter rateLimit;
         mutable data::networking::Http http;
-        mutable MatterpoolApi api;
+        mutable MatterPool::Api api;
         mutable MongoDB_DB db;
 
     };

--- a/include/matterpool_timechain.h
+++ b/include/matterpool_timechain.h
@@ -9,12 +9,12 @@
 #ifndef COSMOSWALLET_MATTERPOOL_TIMECHAIN_H
 #define COSMOSWALLET_MATTERPOOL_TIMECHAIN_H
 
-namespace Cosmos {
+namespace Cosmos::MatterPool {
     constexpr long BSV_FORK_TIMESTAMP = 1542304320;
     constexpr long CASH_FORK_TIMESTAMP = 1501593373;
-    class MatterPool_TimeChain: public Gigamonkey::Bitcoin::timechain {
+    class TimeChain: public Gigamonkey::Bitcoin::timechain {
     public:
-        MatterPool_TimeChain(): rateLimit(100,60) {}
+        TimeChain(): rateLimit(100,60) {}
         double price(Gigamonkey::Bitcoin::timestamp timestamp);
 
         data::list<Gigamonkey::Bitcoin::ledger::block_header> headers(data::uint64 since_height) const override;

--- a/include/types.h
+++ b/include/types.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2021 Katrina Knight
+// Copyright (c) 2021 Daniel Krawisz
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,15 +10,9 @@
 #include <nlohmann/json.hpp>
 #include <gigamonkey/timechain.hpp>
 
-using nlohmann::json;
-
-namespace Gigamonkey {
-    namespace Bitcoin {
-        void from_json(const json& j, header& header);
-        void to_json(json& j, const header& header);
-    }
-}
 namespace Cosmos {
+    using json = nlohmann::json;
+    
     std::vector<char> HexToBytes(const std::string& hex);
 
     namespace BitcoinHeader {

--- a/main.cpp
+++ b/main.cpp
@@ -5,7 +5,7 @@
 
 int main() {
     std::cout << "Hello, World!" << std::endl;
-    Cosmos::MatterPool_TimeChain timechain;
+    Cosmos::MatterPool::TimeChain timechain;
     Gigamonkey::digest<32> digest("0x874999FF562C52EFF5062514FF1EDD1516741C1B7A0919B49B56E427071E8081");
 
     auto tmp=timechain.transaction(digest);

--- a/src/MatterpoolAPI.cpp
+++ b/src/MatterpoolAPI.cpp
@@ -5,9 +5,81 @@
 #include "MatterpoolAPI.h"
 #include "types.h"
 
-namespace Cosmos {
+namespace Cosmos::MatterPool {
+    
+    void from_json(const json &j, Header &header) {
+        using namespace Gigamonkey;
+        using namespace data;
+        
+        uint32 version;
+        j.at("version").get_to(version);
+        header.Version=version;
+        std::string merkle;
+        j.at("merkleroot").get_to(merkle);
+        digest256 tmp("0x"+merkle);
+        header.MerkleRoot=tmp;
+        uint32 nonce;
+        j.at("nonce").get_to(nonce);
+        header.Nonce=nonce;
+        std::string previous;
+        j.at("previousblockhash").get_to(previous);
+        digest256 previousTmp("0x"+previous);
+        header.Previous=previousTmp;
+        uint32 tmpTimestamp;
+        j.at("time").get_to(tmpTimestamp);
 
-    data::list<Gigamonkey::Bitcoin::ledger::block_header> MatterpoolApi::headers(data::uint64 since_height){
+        header.Timestamp=Gigamonkey::Bitcoin::timestamp(tmpTimestamp);
+        std::string target;
+        j.at("bits").get_to(target);
+        unsigned int x;
+        std::stringstream ss;
+        ss << std::hex << target;
+        ss >> x;
+        header.Target=Gigamonkey::work::compact(x);
+
+        /*j.at("height").get_to(header.height);
+
+        std::string hash;
+        j.at("hash").get_to(hash);
+        std::vector<char> hashBytes=HexToBytes(hash);
+        memcpy(header.hash,&hashBytes[0],32);
+        j.at("size").get_to(header.size);
+        j.at("version").get_to(header.version);
+        std::string merkle;
+        j.at("merkleroot").get_to(merkle);
+        std::vector<char> merkleBytes=HexToBytes(merkle);
+        memcpy(header.merkle_root, &merkleBytes[0], 32);
+        j.at("time").get_to(header.timestamp);
+        j.at("nonce").get_to(header.nonce);
+        std::string bits;
+        j.at("bits").get_to(bits);
+        std::istringstream converter(bits);
+        converter >> std::hex >> header.bits;
+        std::string difficulty;
+        j.at("difficulty").get_to(difficulty);
+        header.difficulty = std::stold(difficulty.c_str());
+        std::string previous;
+        j.at("previousblockhash").get_to(previous);
+        std::vector<char> previousBytes=HexToBytes(previous);
+        memcpy(header.prev_block,&previousBytes[0],32);
+        std::string next;
+        j.at("nextblockhash").get_to(next);
+        if(!next.empty()) {
+            std::vector<char> nextBytes = HexToBytes(next);
+            memcpy(header.next_block, &nextBytes[0], 32);
+        }
+        j.at("coinbaseinfo").get_to(header.coinbase_info);
+        j.at("coinbasetxid").get_to(header.coinbase_txid);
+        std::string chain_work;
+        j.at("chainwork").get_to(chain_work);
+        std::vector<char> chainBytes =HexToBytes(chain_work);
+        memcpy(header.chain_work,&chainBytes[0],32);*/
+
+
+
+    }
+
+    data::list<Gigamonkey::Bitcoin::ledger::block_header> Api::headers(data::uint64 since_height){
         auto ret=data::list<Gigamonkey::Bitcoin::headers::header>();
         int i=0;
         json jOutput;
@@ -17,7 +89,7 @@ namespace Cosmos {
             i++;
             jOutput=json::parse(output);
             for(json headerData : jOutput["result"]) {
-                Gigamonkey::Bitcoin::header header = headerData;
+                Header header = headerData;
                 //header(digest256 s, Bitcoin::header h, N n, work::difficulty d) : Hash{s}, Header{h}, Height{n}, Cumulative{d} {}
                 std::string diffString;
 
@@ -40,13 +112,13 @@ namespace Cosmos {
         return ret;
     }
 
-    void MatterpoolApi::waitForRateLimit() {
+    void Api::waitForRateLimit() {
         long waitTime=rateLimit.getTime();
         if(waitTime > 0)
             sleep(waitTime);
     }
 
-    data::bytes MatterpoolApi::transaction(const Gigamonkey::digest<32> &digest)   {
+    data::bytes Api::transaction(const Gigamonkey::digest<32> &digest)   {
         auto tmp=data::encoding::hex::write(digest,data::endian::order::little,data::encoding::hex::letter_case::lower);
         waitForRateLimit();
         std::string output=http.GET("media.bitcoinfiles.org","/tx/"+ tmp+"/raw");
@@ -56,7 +128,7 @@ namespace Cosmos {
         return data::bytes_view(data::encoding::hex::view{output});
     }
 
-    json MatterpoolApi::header(const Gigamonkey::digest<32> &digest) {
+    json Api::header(const Gigamonkey::digest<32> &digest) {
         auto tmp=data::encoding::hex::write(digest,data::endian::order::little,data::encoding::hex::letter_case::lower);
         waitForRateLimit();
         std::string output=this->http.GET("txdb.mattercloud.io","/api/v1/blockheader/"+ tmp+"?limit=1&order=asc");
@@ -64,7 +136,7 @@ namespace Cosmos {
         return jOutput["result"][0];
     }
 
-    data::bytes MatterpoolApi::raw_header(const Gigamonkey::digest<32> &digest) {
+    data::bytes Api::raw_header(const Gigamonkey::digest<32> &digest) {
         auto tmp=data::encoding::hex::write(digest,data::endian::order::little,data::encoding::hex::letter_case::lower);
         waitForRateLimit();
         std::string output=http.GET("media.bitcoinfiles.org","/rawblockheader/"+ tmp);
@@ -74,7 +146,7 @@ namespace Cosmos {
         return data::bytes_view(data::encoding::hex::view{output});
     }
 
-    json MatterpoolApi::header(data::uint64 height) {
+    json Api::header(data::uint64 height) {
 
         waitForRateLimit();
         std::string output=this->http.GET("txdb.mattercloud.io","/api/v1/blockheader/"+ std::to_string(height)+"?limit=1&order=asc");
@@ -82,7 +154,7 @@ namespace Cosmos {
         return jOutput["result"][0];
     }
 
-    data::uint64 MatterpoolApi::transaction_height(Gigamonkey::digest256 &txid) {
+    data::uint64 Api::transaction_height(Gigamonkey::digest256 &txid) {
         auto tmp=data::encoding::hex::write(txid,data::endian::order::little,data::encoding::hex::letter_case::lower);
         waitForRateLimit();
         std::string output=this->http.GET("txdb.mattercloud.io","/api/v1/txblock/"+ tmp);
@@ -92,7 +164,7 @@ namespace Cosmos {
 
 
 
-    json MatterpoolApi::transactions(const Gigamonkey::Bitcoin::address address) {
+    json Api::transactions(const Gigamonkey::Bitcoin::address address) {
         auto tmp=address.write();
         waitForRateLimit();
         std::string output=this->http.GET("txdb.mattercloud.io","/api/v1/txout/address/history/"+tmp);

--- a/src/matterpool_timechain.cpp
+++ b/src/matterpool_timechain.cpp
@@ -4,9 +4,9 @@
 
 #include "matterpool_timechain.h"
 
-namespace Cosmos{
+namespace Cosmos::MatterPool {
 
-    data::list<Gigamonkey::Bitcoin::ledger::block_header> MatterPool_TimeChain::headers(data::uint64 since_height) const {
+    data::list<Gigamonkey::Bitcoin::ledger::block_header> TimeChain::headers(data::uint64 since_height) const {
         //auto vals=this->api.headers(since_height);
         data::list<Gigamonkey::Bitcoin::ledger::block_header> headers=api.headers(since_height);
         for(auto header:headers) {
@@ -16,7 +16,7 @@ namespace Cosmos{
         //return data::list<Gigamonkey::uint<80>>();
     }
 
-    data::entry<Gigamonkey::Bitcoin::txid, Gigamonkey::Bitcoin::ledger::double_entry> MatterPool_TimeChain::transaction(const Gigamonkey::digest<32> &txid) const {
+    data::entry<Gigamonkey::Bitcoin::txid, Gigamonkey::Bitcoin::ledger::double_entry> TimeChain::transaction(const Gigamonkey::digest<32> &txid) const {
 
         Gigamonkey::Bitcoin::ledger::double_entry dentry;
         auto cache=db.get_transaction(txid);
@@ -39,7 +39,7 @@ namespace Cosmos{
 
 
 
-    Gigamonkey::Bitcoin::ledger::block_header MatterPool_TimeChain::header(const Gigamonkey::digest<32> &digest) const {
+    Gigamonkey::Bitcoin::ledger::block_header TimeChain::header(const Gigamonkey::digest<32> &digest) const {
         auto headerOut=db[digest];
 
         if(!headerOut.valid()) {
@@ -63,21 +63,21 @@ namespace Cosmos{
     }
 
 
-    void MatterPool_TimeChain::waitForRateLimit() const {
+    void TimeChain::waitForRateLimit() const {
         long waitTime=rateLimit.getTime();
         if(waitTime > 0)
             sleep(waitTime);
     }
 
-    Gigamonkey::bytes MatterPool_TimeChain::block(const Gigamonkey::digest256 &) const {
+    Gigamonkey::bytes TimeChain::block(const Gigamonkey::digest256 &) const {
         return Gigamonkey::bytes();
     }
 
-    bool MatterPool_TimeChain::broadcast(const data::bytes_view &) {
+    bool TimeChain::broadcast(const data::bytes_view &) {
         return false;
     }
 
-    Gigamonkey::Bitcoin::ledger::block_header MatterPool_TimeChain::header(data::uint64 height) const {
+    Gigamonkey::Bitcoin::ledger::block_header TimeChain::header(data::uint64 height) const {
         auto headerOut=db[height];
 
         if(!headerOut.valid()) {
@@ -104,7 +104,7 @@ namespace Cosmos{
     }
 
     data::list<data::entry<Gigamonkey::Bitcoin::txid, Gigamonkey::Bitcoin::ledger::double_entry>>
-    MatterPool_TimeChain::transactions(const Gigamonkey::Bitcoin::address address) {
+    TimeChain::transactions(const Gigamonkey::Bitcoin::address address) {
         auto txids=api.transactions(address);
         data::list<data::entry<Gigamonkey::Bitcoin::txid, Gigamonkey::Bitcoin::ledger::double_entry>> ret;
         for(json tx : txids) {
@@ -131,7 +131,7 @@ namespace Cosmos{
         }
         return ret;
     }
-    double MatterPool_TimeChain::price(Gigamonkey::Bitcoin::timestamp timestamp) {
+    double TimeChain::price(Gigamonkey::Bitcoin::timestamp timestamp) {
         time_t rawtime=static_cast<time_t>(uint32_t(timestamp));
         struct tm * timeinfo;
         char buffer [11];

--- a/src/matterpool_timechain.cpp
+++ b/src/matterpool_timechain.cpp
@@ -44,7 +44,7 @@ namespace Cosmos{
 
         if(!headerOut.valid()) {
             json data = api.header(digest);
-            Gigamonkey::Bitcoin::header header = data;
+            MatterPool::Header header = data;
             //header(digest256 s, Bitcoin::header h, N n, work::difficulty d) : Hash{s}, Header{h}, Height{n}, Cumulative{d} {}
             std::string diffString;
 
@@ -82,7 +82,7 @@ namespace Cosmos{
 
         if(!headerOut.valid()) {
             json data = api.header(height);
-            Gigamonkey::Bitcoin::header header = data;
+            MatterPool::Header header = data;
             //header(digest256 s, Bitcoin::header h, N n, work::difficulty d) : Hash{s}, Header{h}, Height{n}, Cumulative{d} {}
             std::string diffString;
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2021 Katrina Knight
+// Copyright (c) 2021 Daniel Krawisz
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,78 +10,6 @@
 #include <sstream>
 #include <string>     // std::string, std::stod
 #include <iomanip>
-void Gigamonkey::Bitcoin::from_json(const json &j, header &header) {
-    uint32 version;
-    j.at("version").get_to(version);
-    header.Version=version;
-    std::string merkle;
-    j.at("merkleroot").get_to(merkle);
-    digest256 tmp("0x"+merkle);
-    header.MerkleRoot=tmp;
-    uint32 nonce;
-    j.at("nonce").get_to(nonce);
-    header.Nonce=nonce;
-    std::string previous;
-    j.at("previousblockhash").get_to(previous);
-    digest256 previousTmp("0x"+previous);
-    header.Previous=previousTmp;
-    uint32 tmpTimestamp;
-    j.at("time").get_to(tmpTimestamp);
-
-    header.Timestamp=Gigamonkey::Bitcoin::timestamp(tmpTimestamp);
-    std::string target;
-    j.at("bits").get_to(target);
-    unsigned int x;
-    std::stringstream ss;
-    ss << std::hex << target;
-    ss >> x;
-    header.Target=Gigamonkey::work::compact(x);
-
-    /*j.at("height").get_to(header.height);
-
-    std::string hash;
-    j.at("hash").get_to(hash);
-    std::vector<char> hashBytes=HexToBytes(hash);
-    memcpy(header.hash,&hashBytes[0],32);
-    j.at("size").get_to(header.size);
-    j.at("version").get_to(header.version);
-    std::string merkle;
-    j.at("merkleroot").get_to(merkle);
-    std::vector<char> merkleBytes=HexToBytes(merkle);
-    memcpy(header.merkle_root, &merkleBytes[0], 32);
-    j.at("time").get_to(header.timestamp);
-    j.at("nonce").get_to(header.nonce);
-    std::string bits;
-    j.at("bits").get_to(bits);
-    std::istringstream converter(bits);
-    converter >> std::hex >> header.bits;
-    std::string difficulty;
-    j.at("difficulty").get_to(difficulty);
-    header.difficulty = std::stold(difficulty.c_str());
-    std::string previous;
-    j.at("previousblockhash").get_to(previous);
-    std::vector<char> previousBytes=HexToBytes(previous);
-    memcpy(header.prev_block,&previousBytes[0],32);
-    std::string next;
-    j.at("nextblockhash").get_to(next);
-    if(!next.empty()) {
-        std::vector<char> nextBytes = HexToBytes(next);
-        memcpy(header.next_block, &nextBytes[0], 32);
-    }
-    j.at("coinbaseinfo").get_to(header.coinbase_info);
-    j.at("coinbasetxid").get_to(header.coinbase_txid);
-    std::string chain_work;
-    j.at("chainwork").get_to(chain_work);
-    std::vector<char> chainBytes =HexToBytes(chain_work);
-    memcpy(header.chain_work,&chainBytes[0],32);*/
-
-
-
-}
-
-void Gigamonkey::Bitcoin::to_json(json &j, const Gigamonkey::Bitcoin::header &header) {
-
-}
 
 std::vector<char> Cosmos::HexToBytes(const std::string &hex) {
     std::vector<char> bytes;


### PR DESCRIPTION
Functions from_json and to_json were here in namespace Gigamonkey::Bitcoin. The problem with this is that bitcoin headers do not have a defined json representation. Gigamonkey::Bitcoin::header is supposed to be just a Bitcoin header, not anything else. Potentially, a different API we use could use a different json representation. Some particular json representation shouldn't be associated with this type. 

I have solved this by creating a Cosmos::MatterPool namespace with a type Header that inherents from Gigamonkey::Bitcoin::headers and also has from_json and to_json. 

MatterPoolApi is now MatterPool::api and MatterPool_Timechain is now MatterPool::Timechain